### PR TITLE
Match to injectGlobal function.

### DIFF
--- a/styled-components.xml
+++ b/styled-components.xml
@@ -5,6 +5,7 @@
     <suffix>}</suffix>
     <place><![CDATA[jsLiteralExpression().and(jsArgument("styled", 0))]]></place>
     <place><![CDATA[jsLiteralExpression().withParent(psiElement().withText(string().startsWith("styled")))]]></place>
+    <place><![CDATA[jsLiteralExpression().withParent(psiElement().withText(string().startsWith("injectGlobal")))]]></place>
     <place><![CDATA[jsLiteralExpression().withParent(psiElement().withParent(psiElement().withText(string().startsWith("Styled"))))]]></place>
   </injection>
 </LanguageInjectionConfiguration>


### PR DESCRIPTION
In our codebase, the styles are frequently injected globally, via the [injectGlobal function](https://www.styled-components.com/docs/api) (the direct link is broken on their docs, sorry, CTRL-F will lead you to it).

This adds the injectGlobal to the list of matches.